### PR TITLE
FIX: call start() after NDEdgePlugin object is created for plugin to work for ADCore >= 2.5,  don't process plugin if input NDArray dimension > 2 (i.e. for Color modes)

### DIFF
--- a/edgeApp/edgeSrc/NDPluginEdge.cpp
+++ b/edgeApp/edgeSrc/NDPluginEdge.cpp
@@ -95,6 +95,19 @@ void NDPluginEdge::processCallbacks(NDArray *pArray)
   /* Call the base class method */
   NDPluginDriver::processCallbacks(pArray);
 
+  /* This plugin currently only works for 1-D or 2-D arrays */
+  switch (pArray->ndims) {
+    case 1:
+    case 2:
+      break;
+    default:
+      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+        "%s::%s: error, input array dimensions must be 1 or 2\n",
+        driverName, functionName);
+      return;
+      break;
+  }
+
   getDoubleParam( NDPluginEdgeLowThreshold,   &lowThreshold);
   getDoubleParam( NDPluginEdgeThresholdRatio, &thresholdRatio);
 
@@ -317,10 +330,9 @@ extern "C" int NDEdgeConfigure(const char *portName, int queueSize, int blocking
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginEdge(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                        maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
-}
+    NDPluginEdge *pPlugin = new NDPluginEdge(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                              maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 
 /* EPICS iocsh shell commands */
 static const iocshArg initArg0 = { "portName",iocshArgString};


### PR DESCRIPTION
 This commit fixes 2 minor issues:
1. The plugin is missing the start() method which is called after the object is created. This is required for ADCore >= 2.5
2. If the input NDArray dimension > 2 ( e.g for Color Modes) then the ioc crashes, so don't process the plugin for such cases.

I tested this on windows-x64-static, areaDetector-2-5, and opencv-2.4.13